### PR TITLE
Add real-time sync for favourites and enable image removal from popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "pexels-infinite-gallery",
-  "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,10 +17,11 @@ function App() {
       {popUp && (
         <FavouritesPopUp
           favourites={favourites}
+          setFavourites={setFavourites}
           onClose={() => setPopUp(false)}
         />
       )}
-      <Gallery handleOpenPopUp={handleOpenPopUp} />
+      <Gallery handleOpenPopUp={handleOpenPopUp} favourites={favourites} />
     </>
   );
 }

--- a/src/components/FavouritesPopUp/FavouritesPopUp.jsx
+++ b/src/components/FavouritesPopUp/FavouritesPopUp.jsx
@@ -1,7 +1,19 @@
 import { createPortal } from "react-dom";
+import ImageCard from "../ImageCard/ImageCard.jsx";
 import "./FavouritesPopUp.css";
 
-export default function FavouritesPopUp({ favourites, onClose }) {
+export default function FavouritesPopUp({
+  favourites,
+  setFavourites,
+  onClose,
+}) {
+  const handleRemove = (id) => {
+    const updated = favourites.filter((photo) => photo.id !== id);
+    setFavourites(updated);
+
+    localStorage.setItem("likedPhotos", JSON.stringify(updated));
+  };
+
   return createPortal(
     <div className="popup-backdrop" onClick={onClose}>
       <div
@@ -25,12 +37,11 @@ export default function FavouritesPopUp({ favourites, onClose }) {
             <p>No favourites yet</p>
           ) : (
             favourites.map((photo) => (
-              <img
+              <ImageCard
                 key={photo.id}
-                src={photo.src.large}
-                alt={photo.alt}
-                className="popup-image"
-                loading="lazy"
+                photo={photo}
+                hideFavouriteButton
+                onRemove={() => handleRemove(photo.id)}
               />
             ))
           )}

--- a/src/components/Gallery/Gallery.jsx
+++ b/src/components/Gallery/Gallery.jsx
@@ -5,7 +5,7 @@ import ImageCard from "../ImageCard/ImageCard";
 import NavBar from "../NavBar/NavBar";
 import "./Gallery.css";
 
-export default function Gallery({ handleOpenPopUp }) {
+export default function Gallery({ handleOpenPopUp, favourites }) {
   const [page, setPage] = useState(1);
   const [query, setQuery] = useState("");
   const [inputValue, setInputValue] = useState("");
@@ -48,7 +48,7 @@ export default function Gallery({ handleOpenPopUp }) {
           </p>
         )}
         {data.map((photo) => (
-          <ImageCard key={photo.id} photo={photo} />
+          <ImageCard key={photo.id} photo={photo} favouritesList={favourites} />
         ))}
       </div>
     </>

--- a/src/components/ImageCard/ImageCard.jsx
+++ b/src/components/ImageCard/ImageCard.jsx
@@ -1,8 +1,13 @@
 import "./ImageCard.css";
 import useFavourite from "../../hooks/useFavourite";
 
-export default function ImageCard({ photo }) {
-  const { isFavourited, handleFav } = useFavourite(photo);
+export default function ImageCard({
+  photo,
+  hideFavouriteButton = false,
+  onRemove,
+  favouritesList,
+}) {
+  const { isFavourited, handleFav } = useFavourite(photo, favouritesList);
   return (
     <>
       <div className="image-card">
@@ -15,12 +20,18 @@ export default function ImageCard({ photo }) {
               <p className="photo-photographer">{photo.photographer}</p>
             </div>
             <div className="button-wrapper">
-              <button
-                className={isFavourited ? "fav-btn-active" : "fav-btn"}
-                onClick={handleFav}
-              >
-                {isFavourited ? "Favourited" : "Favourite"}
-              </button>
+              {!hideFavouriteButton ? (
+                <button
+                  className={isFavourited ? "fav-btn-active" : "fav-btn"}
+                  onClick={handleFav}
+                >
+                  {isFavourited ? "Favourited" : "Favourite"}
+                </button>
+              ) : onRemove ? (
+                <button className="remove-btn" onClick={onRemove}>
+                  Remove
+                </button>
+              ) : null}
             </div>
           </div>
         </div>

--- a/src/hooks/useFavourite.jsx
+++ b/src/hooks/useFavourite.jsx
@@ -1,16 +1,17 @@
 import { useState, useEffect } from "react";
 
-export default function useFavourite(photo) {
+export default function useFavourite(photo, favouritesList = null) {
   const [isFavourited, setIsFavourited] = useState(false);
+
   function getStoredPhotos() {
     return JSON.parse(localStorage.getItem("likedPhotos")) || [];
   }
 
   useEffect(() => {
-    const stored = getStoredPhotos();
+    const stored = favouritesList || getStoredPhotos();
     const isLiked = stored.some((item) => item.id === photo.id);
     setIsFavourited(isLiked);
-  }, [photo.id]);
+  }, [photo.id, favouritesList]);
 
   function handleFav() {
     const stored = getStoredPhotos();


### PR DESCRIPTION
- Passed favourites state and updater from App to Gallery and FavouritesPopUp
- Updated ImageCard to support conditional favourite and remove buttons
- Modified useFavourite hook to accept external favourites list for sync
- Ensured UI updates immediately when an image is removed from favourites